### PR TITLE
Fix computeBufferSize returning garbage due to destructuring

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -336,13 +336,13 @@ class BitStruct extends Struct {
     let size = 0;
     for (let i = 0; i < ind; i++) {
       const field = this.fields[i][1];
-        size += field.size;
+        size += field._size;
     }
     return size;
   }
 
   computeBufferSize() {
-    const bits = this.fields.reduce((acc, [_, {size}]) => acc + size, 0);
+    const bits = this.fields.reduce((acc, [_, {_size}]) => acc + _size, 0);
     return Math.ceil(bits / 8);
   }
 


### PR DESCRIPTION
I observed that BitStruct was not working (returning `[null]`).  On investigation the root cause was in `computeBufferSize`, where the destructuring was returning the `size` function, rather than the intended `_size` field - presumably due to a renaming at some point in time.

This pull request fixes the destructuring in `computeBufferSize` and similar error in `getOffset`