### PR TITLE
Ensure BitStructs are in expected (MSb to LSb) order

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "construct-js",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -208,11 +208,11 @@ Returns a regular `Array` representation of the Struct.
 
 ### BitStruct
 
-`BitStruct(name)`
+`BitStruct(name, lsbFirst = true)`
 
-Creates a BitStruct object, for storing and addressing data on the sub-byte level.
+Creates a BitStruct object, for storing and addressing data on the sub-byte level. If *lsbFirst* is `true`, the resulting buffer will consider the fields to be ordered from the 0th bit i.e. the first field in the BitStruct will be the least significant bit in the Buffer. If *lsbFirst* is `false`, the Buffer will contain the fields in the order they are specified.
 
-**Note**: When [bitStruct.toBuffer()](#tobuffer-1) is used, the resulting buffer will be byte aligned. This means if the size of the BitStruct is 12-bits, the resulting buffer will be 16-bits (2 bytes).
+**Note**: When [bitStruct.toBuffer()](#tobuffer-1) is used, the resulting buffer will be byte aligned. This means if the size of the BitStruct is 12-bits, the resulting buffer will be 16-bits (2 bytes). When *lsbFirst* is true, the most significant bits will be padded.
 
 #### flag
 

--- a/src/index.js
+++ b/src/index.js
@@ -299,7 +299,8 @@ class Bits {
 
   getBits() {
     return Array.from({length: this._size}, (_, i) => {
-      return (this._value & 2**i) >> i
+      const shift = this._size - (i+1)
+      return (this._value >> shift) & 0x01
     });
   }
 
@@ -347,25 +348,18 @@ class BitStruct extends Struct {
   }
 
   toBuffer() {
+    return Buffer.from(this.toBytes());
+  }
+
+  toBytes() {
     const bits = this.fields.reduce((bits, [_, field]) => {
       return [...bits, ...field.getBits()];
     }, []);
 
-    const bytes = bits.reduce((bytes, bit, i) => {
-      const byteIndex = Math.floor(i/8);
-      const bitIndex = i % 8;
-      bytes[byteIndex] += bit << bitIndex;
-      return bytes;
-    }, Array.from({length: this.computeBufferSize()}).fill(0));
-
-    return Buffer.from(bytes);
-  }
-
-  toBytes() {
     return bits.reduce((bytes, bit, i) => {
       const byteIndex = Math.floor(i/8);
       const bitIndex = i % 8;
-      bytes[byteIndex] += bit << bitIndex;
+      bytes[byteIndex] += bit << (7 - bitIndex);
       return bytes;
     }, Array.from({length: this.computeBufferSize()}).fill(0));
   }


### PR DESCRIPTION
Creating a buffer from a BitStruct results in the fields being rendered in reverse from the order they were specified.  `getBits()` on a MultiBit field also renders the bits in reverse order, but to add to the confusion when rendered as part of the BitStruct, the reversal is reversed, so it's the right way round :). 

Example:
```   
const mb = dz.BitStruct('bits')
      .flag('a', false)
      .flag('b', true)
      .multiBit('c', 4, 10)
``` 

I would expect to render "left to right" a/b/c/[pad], so 0/1/1010/00, or 68 hex.  The code as it stands generates 00/1010/1/0 (2a hex).  Perhaps this is actually intentional, but seems a bit counterintuitive?

This pull request fixes both those issues to produce fields in the order in which they are specified, and also refactors to fix a bug in the `toBytes()` method that had a undefined field `bits`

Thanks for the library though, just what I'm needing :)