### PR TITLE
Use TS assertion signature to avoid type casting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-const assert = (condition: boolean, message: string) => {
+function assert(condition: boolean, message: string): asserts condition {
   if (!condition) {
     throw new Error(message);
   }
@@ -76,7 +76,7 @@ export class StructType implements IField {
     }
 
     assert(nextPart instanceof StructType, `Item in path "${head}" is not a Struct`);
-    return (nextPart as StructType).getDeep<T>(tail.join('.'));
+    return nextPart.getDeep<T>(tail.join('.'));
   }
 
   getDeepOffset(path: string, startOffset = 0): number {
@@ -91,7 +91,7 @@ export class StructType implements IField {
     }
 
     assert(nextPart instanceof StructType, `Item in path "${head}" is not a Struct`);
-    return (nextPart as StructType).getDeepOffset(tail.join('.'), nextOffset);
+    return nextPart.getDeepOffset(tail.join('.'), nextOffset);
   }
 
   getOffset(name: string) {


### PR DESCRIPTION
Starting from TS 3.7 it's possible to use so-called "assertion signatures" to narrow TS types after guard statements. It's described here: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions

It allows to avoid type casting. For some reason assertion signatures are available only for `function` keyword, that's why I had replace `const` with `function`

- [ ] This PR  only introduces changes to documentation.
  - No
- [ ] This PR adds new functionality
  - [ ] Is there a related issue?
    - No, it's just a an improvement utilizing latest TS features
  - [ ] Does the code style reasonably match the existing code?
    - Yes
  - [ ] Are the changes tested (using the existing format, as far as is possible?)
    - Yes
  - [ ] Are the changes documented in the readme with a suitable example?
    - Not needed
  - [ ] Is the table of contents updated?
    - Not needed
  - [ ] Is the `index.d.ts` file updated, using the same (or appropriately modified) description as in the readme?
    - Not needed

